### PR TITLE
Saving big PNG files.

### DIFF
--- a/ext/oily_png/png_encoding.c
+++ b/ext/oily_png/png_encoding.c
@@ -263,7 +263,7 @@ VALUE oily_png_encode_png_image_pass_to_stream(VALUE self, VALUE stream, VALUE c
   long pass_size  = oily_png_pass_bytesize(FIX2INT(color_mode), depth, width, height);
 
   // Allocate memory for the byte array.
-  BYTE* bytes = ALLOCA_N(BYTE, pass_size);
+  BYTE* bytes = ALLOC_N(BYTE, pass_size);
   
   // Get the scanline encoder function.
   scanline_encoder_func scanline_encoder = oily_png_encode_scanline_func(FIX2INT(color_mode), depth);
@@ -297,5 +297,6 @@ VALUE oily_png_encode_png_image_pass_to_stream(VALUE self, VALUE stream, VALUE c
   
   // Append to encoded image pass to the output stream.
   rb_str_cat(stream, (char*) bytes, pass_size);
+  xfree(bytes);
   return Qnil;
 }


### PR DESCRIPTION
When you try to save big PNG file, segmentation fault error occurs. This occurs because big array is allocated on stack and not on heap. By replacing ALLOCA_N with ALLOC_N and xfree, it is possible to save big files.

The following code was not executing on my computer:

```
require 'oily_png'
image = ChunkyPNG::Image.new(2100, 2100, ChunkyPNG::Color::TRANSPARENT)
image.save("myfile.png")
```

I didn't create any spec test because the above code took 2s to execute, and it was probably too slow for unit tests. 
