### PR TITLE
Add euclidean_distance_rgba

### DIFF
--- a/ext/oily_png/color.c
+++ b/ext/oily_png/color.c
@@ -1,4 +1,5 @@
 #include "oily_png_ext.h"
+#include <math.h>
 
 PIXEL oily_png_compose_color(PIXEL fg, PIXEL bg) {
   BYTE a_com, new_r, new_g, new_b, new_a;
@@ -35,6 +36,15 @@ PIXEL oily_png_color_interpolate_quick(PIXEL fg, PIXEL bg, int alpha) {
 VALUE oily_png_color_compose_quick(VALUE self, VALUE fg_color, VALUE bg_color) {
   UNUSED_PARAMETER(self);
   return UINT2NUM(oily_png_compose_color(NUM2UINT(fg_color), NUM2UINT(bg_color)));
+}
+
+VALUE oily_png_euclidean_distance_rgba(VALUE self, VALUE color_after, VALUE color_before) {
+  UNUSED_PARAMETER(self);
+
+  return rb_float_new(sqrt(pow((R_BYTE(NUM2UINT(color_after)) - R_BYTE(NUM2UINT(color_before))), 2) +
+                           pow((G_BYTE(NUM2UINT(color_after)) - G_BYTE(NUM2UINT(color_before))), 2) +
+                           pow((B_BYTE(NUM2UINT(color_after)) - B_BYTE(NUM2UINT(color_before))), 2) +
+                           pow((A_BYTE(NUM2UINT(color_after)) - A_BYTE(NUM2UINT(color_before))), 2)));
 }
 
 VALUE oily_png_color_r(VALUE self, VALUE value) {

--- a/ext/oily_png/color.h
+++ b/ext/oily_png/color.h
@@ -20,6 +20,9 @@ VALUE oily_png_color_compose_quick(VALUE self, VALUE fg_color, VALUE bg_color);
 PIXEL oily_png_compose_color(PIXEL fg, PIXEL bg);
 PIXEL oily_png_color_interpolate_quick(PIXEL fg, PIXEL bg, int alpha);
 
+/* Color comparison */
+VALUE oily_png_euclidean_distance_rgba(VALUE self, VALUE color_after, VALUE color_before);
+
 /* Accessors */
 VALUE oily_png_color_r(VALUE self, VALUE pixel);
 VALUE oily_png_color_g(VALUE self, VALUE pixel);

--- a/ext/oily_png/oily_png_ext.c
+++ b/ext/oily_png/oily_png_ext.c
@@ -20,6 +20,7 @@ void Init_oily_png() {
   // Setup Color module
   VALUE OilyPNG_Color = rb_define_module_under(OilyPNG, "Color");
   rb_define_method(OilyPNG_Color, "compose_quick", oily_png_color_compose_quick, 2);
+  rb_define_method(OilyPNG_Color, "euclidean_distance_rgba", oily_png_euclidean_distance_rgba, 2);
   rb_define_method(OilyPNG_Color, "r", oily_png_color_r, 1);
   rb_define_method(OilyPNG_Color, "g", oily_png_color_g, 1);
   rb_define_method(OilyPNG_Color, "b", oily_png_color_b, 1);
@@ -38,7 +39,7 @@ char oily_png_samples_per_pixel(char color_mode) {
     case OILY_PNG_COLOR_INDEXED:         return 1;
     case OILY_PNG_COLOR_GRAYSCALE_ALPHA: return 2;
     case OILY_PNG_COLOR_TRUECOLOR_ALPHA: return 4;
-    default: 
+    default:
       rb_raise(rb_eRuntimeError, "Unsupported color mode: %d", color_mode);
       return 0;
   }

--- a/oily_png.gemspec
+++ b/oily_png.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.extensions    = ["ext/oily_png/extconf.rb"]
   s.require_paths = ["lib", "ext"]
 
-  s.add_runtime_dependency('chunky_png', '~> 1.3.0')
+  s.add_runtime_dependency('chunky_png', '~> 1.3.1')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rake-compiler')

--- a/spec/color_spec.rb
+++ b/spec/color_spec.rb
@@ -33,4 +33,17 @@ describe OilyPNG::Color do
       compose_quick(fg, bg).should == ChunkyPNG::Color.compose_quick(fg, bg)
     end
   end
+
+  describe '#euclidean_distance_rgba' do
+    let(:color_a) { rand(0xffffffff) }
+    let(:color_b) { rand(0xffffffff) }
+    subject { euclidean_distance_rgba(color_a, color_b) }
+
+    it { should == ChunkyPNG::Color.euclidean_distance_rgba(color_a, color_b) }
+
+    context 'when both colors are the same' do
+      let(:color_b) { color_a }
+      it { should == 0 }
+    end
+  end
 end


### PR DESCRIPTION
This method was recently added to ChunkyPNG[1](https://github.com/wvanbergen/chunky_png/commit/6e350b2f4a56fb3d07cf2960da51c49a389de1dc). From that commit
message:

  This method simply takes the Euclidean distance between the RGBA
  channels of 2 colors, which gives us a measure of how different the
  two colors are.

  Although it would be more perceptually accurate to calculate a proper
  Delta E in Lab colorspace, this method should serve many use-cases
  while avoiding the overhead of converting RGBA to Lab.

This commit adds the C implementation of this method to OilyPNG.

Note that the specs won't pass until a new version of ChunkyPNG with
`euclidean_disatance_rgba` is released, and OilyPNG is updated to
depend on this version.
