### PR TITLE
Added c extensions for Canvas#rotate_left! and Canvas#rotate_right!

### DIFF
--- a/ext/oily_png/oily_png_ext.c
+++ b/ext/oily_png/oily_png_ext.c
@@ -30,6 +30,8 @@ void Init_oily_png() {
   VALUE OilyPNG_Operations = rb_define_module_under(OilyPNG, "Operations");
   rb_define_method(OilyPNG_Operations, "compose!", oily_png_compose_bang, -1);
   rb_define_method(OilyPNG_Operations, "replace!", oily_png_replace_bang, -1);
+  rb_define_method(OilyPNG_Operations, "rotate_left!", oily_png_rotate_left_bang, 0);
+  rb_define_method(OilyPNG_Operations, "rotate_right!", oily_png_rotate_right_bang, 0);
 }
 
 char oily_png_samples_per_pixel(char color_mode) {

--- a/ext/oily_png/operations.c
+++ b/ext/oily_png/operations.c
@@ -120,3 +120,41 @@ VALUE oily_png_replace_bang(int argc, VALUE *argv, VALUE self) {
   }
   return self;
 }
+
+VALUE oily_png_rotate_left_bang(VALUE self){
+  int store_at;
+  VALUE pixel_value;
+  int canvas_width = NUM2INT(rb_funcall(self, rb_intern("width"), 0));
+  int canvas_height = NUM2INT(rb_funcall(self, rb_intern("height"), 0));
+  VALUE original_pixels = rb_funcall(self, rb_intern("pixels"), 0);
+  VALUE new_pixels = rb_ary_dup(original_pixels);
+  int i, j;
+  for( j = 0 ; j < canvas_width; j++ ){
+    for( i = 0 ; i < canvas_height; i++ ){
+      store_at = (canvas_width - 1 - j)*canvas_height + i;
+      pixel_value = rb_ary_entry(original_pixels, i*canvas_width + j);
+      rb_ary_store(new_pixels, store_at, pixel_value );
+    }
+  }
+  rb_funcall(self, rb_intern("replace_canvas!"), 3, INT2NUM(canvas_height), INT2NUM(canvas_width), new_pixels);
+  return self;
+}
+
+VALUE oily_png_rotate_right_bang(VALUE self){
+  int store_at;
+  VALUE pixel_value;
+  int canvas_width = NUM2INT(rb_funcall(self, rb_intern("width"), 0));
+  int canvas_height = NUM2INT(rb_funcall(self, rb_intern("height"), 0));
+  VALUE original_pixels = rb_funcall(self, rb_intern("pixels"), 0);
+  VALUE new_pixels = rb_ary_dup(original_pixels);
+  int i, j;
+  for( j = 0; j < canvas_width; j++ ){
+    for( i = 0; i < canvas_height; i++ ){
+      store_at = j * canvas_height + (canvas_height - i - 1);
+      pixel_value = rb_ary_entry(original_pixels, i*canvas_width + j);
+      rb_ary_store(new_pixels, store_at, pixel_value );
+    }
+  }
+  rb_funcall(self, rb_intern("replace_canvas!"), 3, INT2NUM(canvas_height), INT2NUM(canvas_width), new_pixels);
+  return self;
+}

--- a/ext/oily_png/operations.h
+++ b/ext/oily_png/operations.h
@@ -33,4 +33,15 @@ VALUE oily_png_compose_bang(int argc, VALUE *argv, VALUE c);
 */
 VALUE oily_png_replace_bang(int argc, VALUE *argv, VALUE c);
 
+
+/*
+  C replacement method for rotating the image 90 degrees counter-clockwise.
+*/
+VALUE oily_png_rotate_left_bang(VALUE self);
+
+/*
+  C replacement method for rotating the image 90 degrees clockwise.
+*/
+VALUE oily_png_rotate_right_bang(VALUE self);
+
 #endif

--- a/lib/oily_png.rb
+++ b/lib/oily_png.rb
@@ -10,6 +10,7 @@ module OilyPNG
     
     base::Color.extend OilyPNG::Color
     base::Canvas.send(:include, OilyPNG::Resampling)
+    base::Canvas.send(:include, OilyPNG::Operations)
   end
 end
 

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -49,4 +49,70 @@ describe OilyPNG::Operations do
       expect { subject.replace!(OilyPNG::Canvas.new(1,1), 16, 16) }.to raise_error
     end
   end
+
+  describe '#rotate_left!' do
+    subject { OilyPNG::Canvas.new(2, 3, [1, 2, 3, 4, 5, 6]) }
+
+    it "should rotate the pixels 90 degrees clockwise" do
+      subject.rotate_left!
+      expect(subject).to eql OilyPNG::Canvas.new(3, 2, [2, 4, 6, 1, 3, 5] )
+    end
+
+    it "should return itself" do
+      expect(subject.rotate_left!).to equal(subject)
+    end
+
+    it "should change the image dimensions" do
+      expect { subject.rotate_left! }.to change { subject.dimension }.
+          from(ChunkyPNG::Dimension('2x3')).to(ChunkyPNG::Dimension('3x2'))
+    end
+
+    it "it should rotate 180 degrees when applied twice" do
+      subject_dup = subject.dup
+      expect(subject.rotate_left!.rotate_left!).to eql subject_dup.rotate_180
+    end
+
+    it "it should rotate right when applied three times" do
+      subject_dup = subject.dup
+      expect(subject.rotate_left!.rotate_left!.rotate_left!).to eql subject_dup.rotate_right!
+    end
+
+    it "should return itself when applied four times" do
+      subject_dup = subject.dup
+      expect(subject.rotate_left!.rotate_left!.rotate_left!.rotate_left!).to eql subject_dup
+    end
+  end
+
+  describe '#rotate_right!' do
+    subject { OilyPNG::Canvas.new(2, 3, [1, 2, 3, 4, 5, 6]) }
+
+    it "should rotate the pixels 90 degrees clockwise" do
+      subject.rotate_right!
+      expect(subject).to eql OilyPNG::Canvas.new(3, 2, [5, 3, 1, 6, 4, 2] )
+    end
+
+    it "should return itself" do
+      expect(subject.rotate_right!).to equal(subject)
+    end
+
+    it "should change the image dimensions" do
+      expect { subject.rotate_right! }.to change { subject.dimension }.
+          from(ChunkyPNG::Dimension('2x3')).to(ChunkyPNG::Dimension('3x2'))
+    end
+
+    it "it should rotate 180 degrees when applied twice" do
+      subject_dup = subject.dup
+      expect(subject.rotate_right!.rotate_right!).to eql subject_dup.rotate_180
+    end
+
+    it "it should rotate left when applied three times" do
+      subject_dup = subject.dup
+      expect(subject.rotate_right!.rotate_right!.rotate_right!).to eql subject_dup.rotate_left
+    end
+
+    it "should return itself when applied four times" do
+      subject_dup = subject.dup
+      expect(subject.rotate_right!.rotate_right!.rotate_right!.rotate_right!).to eql subject_dup
+    end
+  end
 end


### PR DESCRIPTION
The ChunkyPNG rotation methods are very expensive as they use dynamic arrays for pixels. I implemented the Canvas#rotate_left! and Canvas#rotate_right! in C. 

Unittests were copied from ChunkyPNG.

performance improvement:
01.png (727x233): 0.196s vs 0.003s
10.png (6300x3000): 97.869s vs 0.434s
See https://github.com/jappelbe/oily_png/blob/rotation_benchmark/lib/rotation_benchmark.rb for benchmark script and more results
